### PR TITLE
imp(evm): prevent state from being overwhelmed by too many contracts created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (evm) [Evermint#171](https://github.com/EscanBE/evermint/pull/171) Refactor code relates to `proposer address` in `x/evm`
 - (evm) [Evermint#172](https://github.com/EscanBE/evermint/pull/172) Remove unnecessary `block-max-gas` arg in some requests (continue #127)
 - (evm) [Evermint#180](https://github.com/EscanBE/evermint/pull/180) Support EIP-712 message signing for ESIP-179 Staking precompiled contract
+- (evm) [#3](https://github.com/EscanBE/everlast/pull/3) Prevent state from being overwhelmed by too many contracts created
 
 ### Bug Fixes
 

--- a/go.mod
+++ b/go.mod
@@ -268,7 +268,7 @@ replace (
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 	// go-ethereum fork with custom-precompiled-contract support
-	github.com/ethereum/go-ethereum => github.com/EscanBE/go-ethereum-for-evermint v1.10.28
+	github.com/ethereum/go-ethereum => github.com/EscanBE/go-ethereum-for-evermint v1.10.29
 	// Security Advisory https://github.com/advisories/GHSA-h395-qcrw-5vmq
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.1
 	// replace broken goleveldb

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dX
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
 github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/EscanBE/go-ethereum-for-evermint v1.10.28 h1:+Iid0JWaULgPbGAB8lGEn1xqsr+GjeGlFzzTMcjgIIE=
-github.com/EscanBE/go-ethereum-for-evermint v1.10.28/go.mod h1:/6CsT5Ceen2WPLI/oCA3xMcZ5sWMF/D46SjM/ayY0Oo=
+github.com/EscanBE/go-ethereum-for-evermint v1.10.29 h1:uYrAN2AMdj34szLw3JVr8FzfMIFtDXtK2tJICMKPjcU=
+github.com/EscanBE/go-ethereum-for-evermint v1.10.29/go.mod h1:/6CsT5Ceen2WPLI/oCA3xMcZ5sWMF/D46SjM/ayY0Oo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=


### PR DESCRIPTION
Problem: XEN Crypto created too many contracts which made the other Cosmos-based EVM chains suffering.

Opinion: that is not good for healthy of the chain.

That is the only problem that matter so we should only focus on solving this problem via a simple solution.
=> This PR limits the number of contracts can be created by a contract to 10240. This limit should not be easily reached by regular usage.

_Contracts created by contract are contracts which internally deployed during a contract execution, which is exactly the method XEN Crypto used to deploy hundred of contracts in a single transaction._