### PR TITLE
fix(cpc): add pseudocode when query `eth_getCode` and gRPC query code for custom precompiled contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (evm) [Evermint#184](https://github.com/EscanBE/evermint/pull/184) Warmup coinbase + custom-precompiled-contracts and fix some tests
 - (cpc) [Evermint#186](https://github.com/EscanBE/evermint/pull/186) Correct genesis import/export for `x/cpc`
 - (rename-chain) [Evermint#189](https://github.com/EscanBE/evermint/pull/189) Fix broken feature rename-chain
+- (cpc) [#7](https://github.com/EscanBE/everlast/pull/7) Add pseudocode when query `eth_getCode` and gRPC query code for custom precompiled contracts
 
 ### API Breaking
 

--- a/cmd/evld/genesis/improve.go
+++ b/cmd/evld/genesis/improve.go
@@ -3,8 +3,9 @@ package genesis
 import (
 	"encoding/json"
 	"fmt"
-	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"math/big"
+
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 
 	sdkmath "cosmossdk.io/math"
 
@@ -128,7 +129,7 @@ func improveGenesisOfMint(rawGenesisState json.RawMessage, codec codec.Codec) js
 	mintGenesisState.Params.MintDenom = constants.BaseDenom
 	mintGenesisState.Params.GoalBonded = sdkmath.LegacyNewDecWithPrec(50, 2)   // 50%
 	mintGenesisState.Params.InflationMax = sdkmath.LegacyNewDecWithPrec(10, 2) // 10%
-	mintGenesisState.Params.InflationMin = sdkmath.LegacyNewDecWithPrec(03, 2) // 3%
+	mintGenesisState.Params.InflationMin = sdkmath.LegacyNewDecWithPrec(3, 2)  // 3%
 
 	return codec.MustMarshalJSON(&mintGenesisState)
 }

--- a/x/cpc/types/constants.go
+++ b/x/cpc/types/constants.go
@@ -1,5 +1,20 @@
 package types
 
+import "encoding/hex"
+
 const (
 	GasVerifyEIP712 = 200_000
 )
+
+var PseudoCodePrecompiled []byte
+
+func init() {
+	var err error
+	PseudoCodePrecompiled, err = hex.DecodeString(
+		// ABI string of "Custom Precompiled Contract"
+		"0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001b437573746f6d20507265636f6d70696c656420436f6e74726163740000000000",
+	)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -8,6 +8,8 @@ import (
 	"math/big"
 	"time"
 
+	cpctypes "github.com/EscanBE/everlast/v12/x/cpc/types"
+
 	evmvm "github.com/EscanBE/everlast/v12/x/evm/vm"
 
 	errorsmod "cosmossdk.io/errors"
@@ -195,8 +197,16 @@ func (k Keeper) Code(c context.Context, req *evmtypes.QueryCodeRequest) (*evmtyp
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
-
 	address := common.HexToAddress(req.Address)
+
+	{ // check if precompiled, returns a pseudocode to bypass logic check when importing token like Metamask
+		if k.cpcKeeper.HasCustomPrecompiledContract(ctx, address) {
+			return &evmtypes.QueryCodeResponse{
+				Code: cpctypes.PseudoCodePrecompiled,
+			}, nil
+		}
+	}
+
 	codeHash := k.GetCodeHash(ctx, address.Bytes())
 
 	var code []byte


### PR DESCRIPTION
Problem: cannot import custom precompiled contracts created by `x/cpc`

Maybe Metamask has changed behavior to get code first to check if contract or not.

This PR add a pseudo contract code to response to client, just to workaround this issue.